### PR TITLE
WIP: improve goxygen for model settings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2603874'
+ValidationKey: '2937000'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'goxygen: In-Code Documentation for ''GAMS'''
-version: 1.3.3
-date-released: '2023-08-09'
+version: 1.5.0
+date-released: '2023-08-11'
 abstract: A collection of tools which extract a model documentation from 'GAMS' code
   and comments. In order to use the package you need to install 'pandoc' and 'pandoc-citeproc'
   first (<https://pandoc.org/>).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: goxygen
 Type: Package
 Title: In-Code Documentation for 'GAMS'
-Version: 1.3.3
-Date: 2023-08-09
+Version: 1.5.0
+Date: 2023-08-11
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Kristine", "Karstens", email = "karstens@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),

--- a/R/extractDocumentation.R
+++ b/R/extractDocumentation.R
@@ -46,6 +46,12 @@ extractDocumentation <- function(path, start_type=NULL, comment="*'") {
     code <- "@(\\w*) ?(.*)$"
     pattern <- paste0("^(",escapeRegex(comment),") *",code)
     type <- sub(pattern,"\\2",x[1])
+    extraPage <- NULL
+    if (grepl("@code extrapage", x[1])) {
+      extraPage <- gsub(".*@code extrapage=\"([^\"]*)\".*", "\\1", x[1])
+      type <- "code"
+      x[1] <- sub(pattern, "\\1 \\3", x[1])
+    }
     if(type=="equations") {
       x[1] <- sub(pattern,"\\1 \\3",x[1])
       x <- paste(x,collapse="\n")
@@ -83,6 +89,23 @@ extractDocumentation <- function(path, start_type=NULL, comment="*'") {
       x[1] <- sub(code,"\\2",x[1])
     }
     
+    # if (!is.null(extraPage)) {
+    #   dirPath <- "doc/markdown"
+    #   if (!dir.exists(dirPath)) {
+    #   dir.create(dirPath, recursive = TRUE)
+    # }
+    #   mdFile <- paste0(dirPath, "/", extraPage, ".md")
+    #   x <- x[-1]
+    #   write(paste(extraPage, "\n=================================\nDescription\n-----------"), mdFile)
+    #   write(x, mdFile, append = TRUE)
+    # }
+     if (!is.null(extraPage)) {
+        header <- paste0(extraPage, "\n=================================\nDescription\n-----------\n")
+        content <- paste(x[-1], collapse="\n")
+        markdownList <- stats::setNames(list(paste(header, content)), extraPage)
+        buildMarkdown(markdownList, "doc/markdown")
+    }
+
     while(length(x)>1 & x[1]=="")  x <- x[-1]
     while(length(x)>1 & tail(x,1)=="") x <- x[-length(x)]
     if(length(x)==1) if(is.na(x) | x=="") return(NULL)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # In-Code Documentation for 'GAMS'
 
-R package **goxygen**, version **1.3.3**
+R package **goxygen**, version **1.5.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/goxygen)](https://cran.r-project.org/package=goxygen) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1411404.svg)](https://doi.org/10.5281/zenodo.1411404) [![R build status](https://github.com/pik-piam/goxygen/workflows/check/badge.svg)](https://github.com/pik-piam/goxygen/actions) [![codecov](https://codecov.io/gh/pik-piam/goxygen/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/goxygen) [![r-universe](https://pik-piam.r-universe.dev/badges/goxygen)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **goxygen** in publications use:
 
-Dietrich J, Karstens K, Klein D, Baumstark L (2023). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.3.3, <https://github.com/pik-piam/goxygen>.
+Dietrich J, Karstens K, Klein D, Baumstark L (2023). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.5.0, <https://github.com/pik-piam/goxygen>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {goxygen: In-Code Documentation for 'GAMS'},
   author = {Jan Philipp Dietrich and Kristine Karstens and David Klein and Lavinia Baumstark},
   year = {2023},
-  note = {R package version 1.3.3},
+  note = {R package version 1.5.0},
   doi = {10.5281/zenodo.1411404},
   url = {https://github.com/pik-piam/goxygen},
 }

--- a/vignettes/goxygen.R
+++ b/vignettes/goxygen.R
@@ -1,0 +1,23 @@
+## ----setup, include = FALSE---------------------------------------------------
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+
+## ----eval=FALSE---------------------------------------------------------------
+#  setwd(tempdir())
+
+## ----eval=FALSE---------------------------------------------------------------
+#  # copy the folder containing a simple dummy model with goxygen comments
+#  file.copy(from = system.file("dummymodel-plain",package="goxygen"), to = ".", recursive = TRUE)
+
+## ----eval=FALSE---------------------------------------------------------------
+#  goxygen::goxygen(path = "dummymodel-plain/", cff = "HOWTOCITE.cff")
+
+## ----eval=FALSE---------------------------------------------------------------
+#  # copy all files and folders containing the modular dummy model
+#  file.copy(from = system.file("dummymodel",package="gms"), to = ".", recursive = TRUE)
+
+## ----eval=FALSE---------------------------------------------------------------
+#  goxygen::goxygen(path = "dummymodel/", cff = "HOWTOCITE.cff")
+


### PR DESCRIPTION
This pull request introduces improvements to goxygen, allowing developers to organize better and separate model settings from other parts of the documentation. The core of this enhancement extracts setting blocks from the `main.gms` file and uses them to generate distinct web pages.

Setting blocks intended for extraction should be marked with the tag: `@code extrapage="ExtraPageName"`. This tag serves as an identifier and also provides the name for the generated webpage. 

The feature is still under development and I would appreciate any feedback, comments, or contributions to further refine and improve this implementation. If there are specific use cases or scenarios that should be considered, please let me know.