### PR TITLE
remove markdown folder before rebuilding documentation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2775444'
+ValidationKey: '2795980'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'goxygen: In-Code Documentation for ''GAMS'''
-version: 1.4.1
-date-released: '2023-11-23'
+version: 1.4.2
+date-released: '2023-11-29'
 abstract: A collection of tools which extract a model documentation from 'GAMS' code
   and comments. In order to use the package you need to install 'pandoc' and 'pandoc-citeproc'
   first (<https://pandoc.org/>).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: goxygen
 Type: Package
 Title: In-Code Documentation for 'GAMS'
-Version: 1.4.1
-Date: 2023-11-23
+Version: 1.4.2
+Date: 2023-11-29
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Kristine", "Karstens", email = "karstens@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),

--- a/R/goxygen.R
+++ b/R/goxygen.R
@@ -95,6 +95,7 @@ goxygen <- function(path = ".",
 
   if (!dir.exists(docfolder)) dir.create(docfolder, recursive = TRUE)
   if (file.exists("literature.bib")) file.copy("literature.bib", paste0(docfolder, "/literature.bib"), overwrite = TRUE)
+  if (dir.exists(file.path(docfolder, "markdown"))) unlink(file.path(docfolder, "markdown"), recursive = TRUE)
 
   copyimages <- function(docfolder, paths) {
     imagefolder <- paste0(docfolder, "/images")
@@ -140,5 +141,5 @@ goxygen <- function(path = ".",
   if ("html" %in% output) buildHTML(supplementary = "images", citation = citation, style = htmlStyle,
                                     templatefolder = templatefolder)
   if ("tex" %in% output || "pdf" %in% output) buildTEX(pdf = ("pdf" %in% output), citation = citation, style = texStyle,
-                                                      templatefolder = templatefolder)
+                                                       templatefolder = templatefolder)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # In-Code Documentation for 'GAMS'
 
-R package **goxygen**, version **1.4.1**
+R package **goxygen**, version **1.4.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/goxygen)](https://cran.r-project.org/package=goxygen) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1411404.svg)](https://doi.org/10.5281/zenodo.1411404) [![R build status](https://github.com/pik-piam/goxygen/workflows/check/badge.svg)](https://github.com/pik-piam/goxygen/actions) [![codecov](https://codecov.io/gh/pik-piam/goxygen/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/goxygen) [![r-universe](https://pik-piam.r-universe.dev/badges/goxygen)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **goxygen** in publications use:
 
-Dietrich J, Karstens K, Klein D, Baumstark L, Benke F (2023). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.4.1, <https://github.com/pik-piam/goxygen>.
+Dietrich J, Karstens K, Klein D, Baumstark L, Benke F (2023). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.4.2, <https://github.com/pik-piam/goxygen>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {goxygen: In-Code Documentation for 'GAMS'},
   author = {Jan Philipp Dietrich and Kristine Karstens and David Klein and Lavinia Baumstark and Falk Benke},
   year = {2023},
-  note = {R package version 1.4.1},
+  note = {R package version 1.4.2},
   doi = {10.5281/zenodo.1411404},
   url = {https://github.com/pik-piam/goxygen},
 }


### PR DESCRIPTION
Motivation: When removing generated extra pages, they will still show up when recreating documentation in the same doc folder. This is because the md files from the `markdown` folder are not removed, but only overwritten. The markdown folder is the basis for the generated html and pdf pages.

This PR checks if the markdown folder exists already and if so, removes it, to ensure that no longer existing pages are removed. 