### PR TITLE
allow setting startType for documenting realizations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2841840'
+ValidationKey: '2842128'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2815670'
+ValidationKey: '2841840'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'goxygen: In-Code Documentation for ''GAMS'''
 version: 1.4.4
-date-released: '2024-01-13'
+date-released: '2024-01-15'
 abstract: A collection of tools which extract a model documentation from 'GAMS' code
   and comments. In order to use the package you need to install 'pandoc' and 'pandoc-citeproc'
   first (<https://pandoc.org/>).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'goxygen: In-Code Documentation for ''GAMS'''
-version: 1.4.3
-date-released: '2023-11-29'
+version: 1.4.4
+date-released: '2024-01-13'
 abstract: A collection of tools which extract a model documentation from 'GAMS' code
   and comments. In order to use the package you need to install 'pandoc' and 'pandoc-citeproc'
   first (<https://pandoc.org/>).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: goxygen
 Type: Package
 Title: In-Code Documentation for 'GAMS'
-Version: 1.4.3
-Date: 2023-11-29
+Version: 1.4.4
+Date: 2024-01-13
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Kristine", "Karstens", email = "karstens@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
@@ -34,5 +34,5 @@ BugReports: https://github.com/pik-piam/goxygen/issues
 License: BSD_2_clause + file LICENSE
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: goxygen
 Type: Package
 Title: In-Code Documentation for 'GAMS'
 Version: 1.4.4
-Date: 2024-01-13
+Date: 2024-01-15
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Kristine", "Karstens", email = "karstens@pik-potsdam.de", role = "aut"),
              person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),

--- a/R/createListModularCode.R
+++ b/R/createListModularCode.R
@@ -10,9 +10,10 @@
 #' @param includeCore Boolean whether core should be included or not, default=FALSE
 #' @param mainfile main file of the model
 #' @param docfolder folder the documentation should be written to relative to model folder
-#' @param autoDocumentRealizations Boolean indicating whether documentation in realizations
-#'        should be interpreted as equations documentation, if no identifier is set
-#'        (for more info refer to \code{\link{extractDocumentation}}), default=TRUE
+#' @param startType input parameter for \code{\link{extractDocumentation}} to be passed
+#'        when extracting documentation from realizations. Defaults to "equations",
+#'        meaning that documentation in realizations should be interpreted as equations
+#'        documentation, if no identifier is set.
 #' @author Jan Philipp Dietrich
 #' @importFrom stringi stri_extract_all_regex stri_replace_all_regex stri_write_lines
 #' @importFrom gms codeCheck modules_interfaceplot is.modularGAMS
@@ -26,7 +27,7 @@
 createListModularCode <- function(cc, interfaces, path = ".", citation = NULL, # nolint
                                   unitPattern = c("\\(", "\\)"), includeCore = FALSE,
                                   mainfile = "main.gms", docfolder = "doc",
-                                  autoDocumentRealizations = TRUE) {
+                                  startType = "equations") {
 
   local_dir(path)
 
@@ -163,7 +164,7 @@ createListModularCode <- function(cc, interfaces, path = ".", citation = NULL, #
       files <- list.files(path = "core", pattern = "\\.gms")
       paths <- file.path("core", files)
 
-      outSub$realizations[["core"]] <- extractDocumentation(paths, start_type = startType)
+      outSub$realizations[["core"]] <- extractDocumentation(paths, startType = startType)
 
     } else {
       rea <- strsplit(cc$modulesInfo[m, "realizations"], ",")[[1]]
@@ -185,7 +186,7 @@ createListModularCode <- function(cc, interfaces, path = ".", citation = NULL, #
         # mentioned files will be added at the end.
         paths <- union(intersect(mentionedPaths, existingPaths), existingPaths)
 
-        outSub$realizations[[r]] <- extractDocumentation(paths, start_type = startType)
+        outSub$realizations[[r]] <- extractDocumentation(paths, startType = startType)
       }
     }
     return(outSub)
@@ -219,8 +220,6 @@ createListModularCode <- function(cc, interfaces, path = ".", citation = NULL, #
   } else {
     mLoop <- setdiff(sort(names(out)), "core")
   }
-
-  startType <- if (isTRUE(autoDocumentRealizations)) "equations" else NULL
 
   for (m in mLoop) {
     realizations <- collectRealizations(m, cc, startType)

--- a/R/extractDocumentation.R
+++ b/R/extractDocumentation.R
@@ -6,7 +6,7 @@
 #'
 #'
 #' @param path path to the file(s) which should be evaluated
-#' @param start_type set type for first line of code. This can be useful
+#' @param startType set type for first line of code. This can be useful
 #' to extract documentation even if no documentation type has been set (e.g
 #' reading equations.gms as type realization)
 #' @param comment comment chars used for documentation comments
@@ -27,12 +27,12 @@
 #'
 #' @export
 
-extractDocumentation <- function(path, start_type = NULL, comment = "*'") { # nolint
+extractDocumentation <- function(path, startType = NULL, comment = "*'") { # nolint
 
   if (length(path) > 1) {
     out <- list()
     for (p in path) {
-      out <- append(out, extractDocumentation(p, start_type = start_type, comment = comment))
+      out <- append(out, extractDocumentation(p, startType = startType, comment = comment))
     }
     return(out)
   }
@@ -119,8 +119,8 @@ extractDocumentation <- function(path, start_type = NULL, comment = "*'") { # no
   if (!file.exists(path)) return(list())
   x <- readLines(path, warn = FALSE)
   x <- removeComments(x, comment)
-  if (!is.null(start_type)) {
-    x <- c(paste0(comment, " @", start_type, " "), x)
+  if (!is.null(startType)) {
+    x <- c(paste0(comment, " @", startType, " "), x)
   }
 
   regex <- paste0("^", escapeRegex(comment), " @[a-z]*( |(\\{.+\\})|$)")

--- a/R/goxygen.R
+++ b/R/goxygen.R
@@ -50,9 +50,7 @@
 #' @param unitPattern pattern that is usedto identify the unit in the description, default =c("\\(","\\)")
 #' @param includeCore boolean whether core should be included or not, default=FALSE
 #' @param mainfile main file of the model
-#' @param autoDocumentRealizations Boolean indicating whether documentation in realizations
-#'        should be interpreted as equations documentation, if no identifier is set
-#'        (for more info refer to \code{\link{extractDocumentation}}), default=TRUE
+#' @param startType input parameter for \code{\link{createListModularCode}}, default = "equations"
 #' @param ... optional arguments to \code{\link[gms]{interfaceplot}}, passed via
 #' \code{\link[gms]{modules_interfaceplot}}.
 #'
@@ -85,7 +83,7 @@ goxygen <- function(path = ".",
                     unitPattern = c("\\(", "\\)"),
                     includeCore = FALSE,
                     mainfile = "main.gms",
-                    autoDocumentRealizations = TRUE,
+                    startType = "equations",
                     ...) {
   local_dir(path)
 
@@ -131,7 +129,7 @@ goxygen <- function(path = ".",
     full <- createListModularCode(cc = cc, interfaces = interfaces, path = ".", citation = citation,
                                   unitPattern = unitPattern, includeCore = includeCore,
                                   mainfile = mainfile, docfolder = docfolder,
-                                  autoDocumentRealizations = autoDocumentRealizations)
+                                  startType = startType)
   } else {
     copyimages(docfolder, paths = list.files(pattern = "\\.(jpg|png)$", recursive = TRUE))
     full <- createListSimpleCode(path = ".", citation = citation, mainfile = mainfile)

--- a/R/goxygen.R
+++ b/R/goxygen.R
@@ -50,6 +50,9 @@
 #' @param unitPattern pattern that is usedto identify the unit in the description, default =c("\\(","\\)")
 #' @param includeCore boolean whether core should be included or not, default=FALSE
 #' @param mainfile main file of the model
+#' @param autoDocumentRealizations Boolean indicating whether documentation in realizations
+#'        should be interpreted as equations documentation, if no identifier is set
+#'        (for more info refer to \code{\link{extractDocumentation}}), default=TRUE
 #' @param ... optional arguments to \code{\link[gms]{interfaceplot}}, passed via
 #' \code{\link[gms]{modules_interfaceplot}}.
 #'
@@ -82,6 +85,7 @@ goxygen <- function(path = ".",
                     unitPattern = c("\\(", "\\)"),
                     includeCore = FALSE,
                     mainfile = "main.gms",
+                    autoDocumentRealizations = TRUE,
                     ...) {
   local_dir(path)
 
@@ -126,7 +130,8 @@ goxygen <- function(path = ".",
     }
     full <- createListModularCode(cc = cc, interfaces = interfaces, path = ".", citation = citation,
                                   unitPattern = unitPattern, includeCore = includeCore,
-                                  mainfile = mainfile, docfolder = docfolder)
+                                  mainfile = mainfile, docfolder = docfolder,
+                                  autoDocumentRealizations = autoDocumentRealizations)
   } else {
     copyimages(docfolder, paths = list.files(pattern = "\\.(jpg|png)$", recursive = TRUE))
     full <- createListSimpleCode(path = ".", citation = citation, mainfile = mainfile)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # In-Code Documentation for 'GAMS'
 
-R package **goxygen**, version **1.4.3**
+R package **goxygen**, version **1.4.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/goxygen)](https://cran.r-project.org/package=goxygen) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1411404.svg)](https://doi.org/10.5281/zenodo.1411404) [![R build status](https://github.com/pik-piam/goxygen/workflows/check/badge.svg)](https://github.com/pik-piam/goxygen/actions) [![codecov](https://codecov.io/gh/pik-piam/goxygen/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/goxygen) [![r-universe](https://pik-piam.r-universe.dev/badges/goxygen)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **goxygen** in publications use:
 
-Dietrich J, Karstens K, Klein D, Baumstark L, Benke F (2023). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.4.3, <https://github.com/pik-piam/goxygen>.
+Dietrich J, Karstens K, Klein D, Baumstark L, Benke F (2024). _goxygen: In-Code Documentation for 'GAMS'_. doi:10.5281/zenodo.1411404 <https://doi.org/10.5281/zenodo.1411404>, R package version 1.4.4, <https://github.com/pik-piam/goxygen>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,8 +56,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {goxygen: In-Code Documentation for 'GAMS'},
   author = {Jan Philipp Dietrich and Kristine Karstens and David Klein and Lavinia Baumstark and Falk Benke},
-  year = {2023},
-  note = {R package version 1.4.3},
+  year = {2024},
+  note = {R package version 1.4.4},
   doi = {10.5281/zenodo.1411404},
   url = {https://github.com/pik-piam/goxygen},
 }

--- a/man/createListModularCode.Rd
+++ b/man/createListModularCode.Rd
@@ -12,7 +12,8 @@ createListModularCode(
   unitPattern = c("\\\\(", "\\\\)"),
   includeCore = FALSE,
   mainfile = "main.gms",
-  docfolder = "doc"
+  docfolder = "doc",
+  autoDocumentRealizations = TRUE
 )
 }
 \arguments{
@@ -31,6 +32,10 @@ createListModularCode(
 \item{mainfile}{main file of the model}
 
 \item{docfolder}{folder the documentation should be written to relative to model folder}
+
+\item{autoDocumentRealizations}{Boolean indicating whether documentation in realizations
+should be interpreted as equations documentation, if no identifier is set
+(for more info refer to \code{\link{extractDocumentation}}), default=TRUE}
 }
 \description{
 support function to create documentation of modular GAMS code.

--- a/man/createListModularCode.Rd
+++ b/man/createListModularCode.Rd
@@ -13,7 +13,7 @@ createListModularCode(
   includeCore = FALSE,
   mainfile = "main.gms",
   docfolder = "doc",
-  autoDocumentRealizations = TRUE
+  startType = "equations"
 )
 }
 \arguments{
@@ -33,9 +33,10 @@ createListModularCode(
 
 \item{docfolder}{folder the documentation should be written to relative to model folder}
 
-\item{autoDocumentRealizations}{Boolean indicating whether documentation in realizations
-should be interpreted as equations documentation, if no identifier is set
-(for more info refer to \code{\link{extractDocumentation}}), default=TRUE}
+\item{startType}{input parameter for \code{\link{extractDocumentation}} to be passed
+when extracting documentation from realizations. Defaults to "equations",
+meaning that documentation in realizations should be interpreted as equations
+documentation, if no identifier is set.}
 }
 \description{
 support function to create documentation of modular GAMS code.

--- a/man/extractDocumentation.Rd
+++ b/man/extractDocumentation.Rd
@@ -4,12 +4,12 @@
 \alias{extractDocumentation}
 \title{extractDocumentation}
 \usage{
-extractDocumentation(path, start_type = NULL, comment = "*'")
+extractDocumentation(path, startType = NULL, comment = "*'")
 }
 \arguments{
 \item{path}{path to the file(s) which should be evaluated}
 
-\item{start_type}{set type for first line of code. This can be useful
+\item{startType}{set type for first line of code. This can be useful
 to extract documentation even if no documentation type has been set (e.g
 reading equations.gms as type realization)}
 

--- a/man/goxygen.Rd
+++ b/man/goxygen.Rd
@@ -17,7 +17,7 @@ goxygen(
   unitPattern = c("\\\\(", "\\\\)"),
   includeCore = FALSE,
   mainfile = "main.gms",
-  autoDocumentRealizations = TRUE,
+  startType = "equations",
   ...
 )
 }
@@ -56,9 +56,7 @@ templates.}
 
 \item{mainfile}{main file of the model}
 
-\item{autoDocumentRealizations}{Boolean indicating whether documentation in realizations
-should be interpreted as equations documentation, if no identifier is set
-(for more info refer to \code{\link{extractDocumentation}}), default=TRUE}
+\item{startType}{input parameter for \code{\link{createListModularCode}}, default = "equations"}
 
 \item{...}{optional arguments to \code{\link[gms]{interfaceplot}}, passed via
 \code{\link[gms]{modules_interfaceplot}}.}

--- a/man/goxygen.Rd
+++ b/man/goxygen.Rd
@@ -17,6 +17,7 @@ goxygen(
   unitPattern = c("\\\\(", "\\\\)"),
   includeCore = FALSE,
   mainfile = "main.gms",
+  autoDocumentRealizations = TRUE,
   ...
 )
 }
@@ -54,6 +55,10 @@ templates.}
 \item{includeCore}{boolean whether core should be included or not, default=FALSE}
 
 \item{mainfile}{main file of the model}
+
+\item{autoDocumentRealizations}{Boolean indicating whether documentation in realizations
+should be interpreted as equations documentation, if no identifier is set
+(for more info refer to \code{\link{extractDocumentation}}), default=TRUE}
 
 \item{...}{optional arguments to \code{\link[gms]{interfaceplot}}, passed via
 \code{\link[gms]{modules_interfaceplot}}.}


### PR DESCRIPTION
Motivation:

Currently, all gms files in realizations of REMIND are prepended with the equations identifier, which results in automatic inclusion of comments and equations in the goxygen documentation. This implicit approach has led to confusion among REMIND developers. In REMIND, we only want to include equations when stated explicitly by the equations identifier. 

Therefore, we would like allow passing the parameter `startType`  for documenting realizations when calling goxygen  (defaults to "equations", which means current behavior). For REMIND, we will simply set it to NULL.

